### PR TITLE
Create incompatible_runtime.md

### DIFF
--- a/behaviorpack/entity/incompatible_runtime.md
+++ b/behaviorpack/entity/incompatible_runtime.md
@@ -1,0 +1,26 @@
+# Entity - Incompatible Runtime
+
+`behaviorpack.entity.incompatible_runtime`
+
+A specified component is incompatible with the entity's runtime identifier.
+
+## Example
+
+The following will result in an error:
+
+```jsonc
+{
+  "format_version": "1.16.0",
+  "minecraft:entity": {
+    "description": {
+      "identifier": "example:foo",
+      "runtime_identifier": "minecraft:dolphin"
+    },
+    "components": {
+      "minecraft:movement.basic": {}
+    }
+  }
+}
+```
+
+The runtime `minecraft:dolphin` adds the component `minecraft:movement.dolphin` to the entity. There being two movement components causes an error.


### PR DESCRIPTION
For my recent PR to the diagnoser.
I realize the error in the diagnoser is actually `behaviorpack.entity.component.incompatible_runtime` not `behaviorpack.entity.incompatible_runtime`. Will PR a fix for that unless you can do it